### PR TITLE
Add annotations to pods (Helm)

### DIFF
--- a/examples/deployements/aws/onprem/helm-eks-http-sidecar/helm-chart/templates/deployment.yaml
+++ b/examples/deployements/aws/onprem/helm-eks-http-sidecar/helm-chart/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
         "app.kubernetes.io/instance": formal-external-web
   template:
     metadata:
+      annotations: {{ toYaml .Values.podAnnotations | indent 4 }}
       labels:
         "app.kubernetes.io/name": formal-external
         "app.kubernetes.io/instance": formal-external-web


### PR DESCRIPTION
## Context
Introducing the capability in `values.yaml` for customers to specify annotations, including Datadog (DD) annotations, directly on pods

