### PR TITLE
typo native_user_link

### DIFF
--- a/docs/resources/native_user_link.md
+++ b/docs/resources/native_user_link.md
@@ -18,7 +18,7 @@ This resource creates assigns a Native User to a Formal Identity.
 ### Required
 
 - `formal_identity_id` (String) The Formal ID for the User or Group to be linked.
-- `formal_identity_type` (String) The type of Formal Identity to be linked. Accepted values are `role` and `group`.
+- `formal_identity_type` (String) The type of Formal Identity to be linked. Accepted values are `user` and `group`.
 - `native_user_id` (String) The Native User ID of the Native User.
 
 ### Optional

--- a/formal/resources/resource_native_user_link.go
+++ b/formal/resources/resource_native_user_link.go
@@ -45,7 +45,7 @@ func ResourceNativeUserLink() *schema.Resource {
 			},
 			"formal_identity_type": {
 				// This description is used by the documentation generator and the language server.
-				Description: "The type of Formal Identity to be linked. Accepted values are `role` and `group`.",
+				Description: "The type of Formal Identity to be linked. Accepted values are `user` and `group`.",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,


### PR DESCRIPTION
## Context
Typo in native_user_link documentation