### PR TITLE
Fixing the update-able  resource fields for formal resource

### DIFF
--- a/formal/resources/resource_resource.go
+++ b/formal/resources/resource_resource.go
@@ -189,7 +189,7 @@ func resourceDatastoreUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 	// Only enable updates to these fields, err otherwise
 
-	fieldsThatCanChange := []string{"name", "health_check_db_name", "db_discovery_job_wait_time", "db_discovery_native_role_id", "termination_protection", "space_id"}
+	fieldsThatCanChange := []string{"name", "environment", "termination_protection", "space_id"}
 	if d.HasChangesExcept(fieldsThatCanChange...) {
 		err := fmt.Sprintf("At the moment you can only update the following fields: %s. If you'd like to update other fields, please message the Formal team and we're happy to help.", strings.Join(fieldsThatCanChange, ", "))
 		return diag.Errorf(err)


### PR DESCRIPTION
Seems to be referencing the old satellite resource field names- but this prevents updating the formal resource via tf