### PR TITLE
Cloud integrations AWS message

### DIFF
--- a/docs/resources/integration_cloud.md
+++ b/docs/resources/integration_cloud.md
@@ -17,14 +17,12 @@ Registering a Cloud integration.
 
 ### Required
 
-- `aws_template_version` (String) The template version of the CloudFormation stack. Use `latest` to stay in sync.
 - `cloud_region` (String) Region of the cloud provider.
 - `name` (String) Name of the Integration.
-- `type` (String) Type of the Integration. (Supported: aws)
 
 ### Optional
 
-- `aws_s3_bucket_arn` (String) The S3 bucket ARN this Cloud Integration is allowed to use for Log Integrations.
+- `aws` (Block List, Max: 1) Configuration block for AWS integration. (see [below for nested schema](#nestedblock--aws))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -34,6 +32,18 @@ Registering a Cloud integration.
 - `aws_formal_stack_name` (String) A generated name for your CloudFormation stack.
 - `aws_template_body` (String) The template body of the CloudFormation stack.
 - `id` (String) The ID of the Integration.
+
+<a id="nestedblock--aws"></a>
+### Nested Schema for `aws`
+
+Required:
+
+- `template_version` (String) The template version of the CloudFormation stack. Use `latest` to stay in sync.
+
+Optional:
+
+- `s3_bucket_arn` (String) The S3 bucket ARN this Cloud Integration is allowed to use for Log Integrations.
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/examples/deployments/aws/integrations/main.tf
+++ b/examples/deployments/aws/integrations/main.tf
@@ -26,11 +26,13 @@ resource "aws_s3_bucket" "demo" {
 }
 
 resource "formal_integration_cloud" "demo" {
-  name                 = "${var.name}-demo-integration"
-  type                 = "aws"
-  cloud_region         = var.region
-  aws_template_version = "1.1.0"
-  aws_s3_bucket_arn    = aws_s3_bucket.demo.arn
+  name         = "${var.name}-demo-integration"
+  cloud_region = var.region
+
+  aws {
+    template_version = "1.1.0"
+    s3_bucket_arn    = aws_s3_bucket.demo.arn
+  }
 }
 
 resource "aws_cloudformation_stack" "demo" {
@@ -40,6 +42,7 @@ resource "aws_cloudformation_stack" "demo" {
     FormalIAMRoleId     = formal_integration_cloud.demo.aws_formal_iam_role
     FormalSNSTopicARN   = formal_integration_cloud.demo.aws_formal_pingback_arn
     FormalIntegrationId = formal_integration_cloud.demo.id
+    S3BucketARN         = aws_s3_bucket.demo.arn
   }
   capabilities = ["CAPABILITY_NAMED_IAM"]
   depends_on = [

--- a/formal/resources/resource_integration_cloud.go
+++ b/formal/resources/resource_integration_cloud.go
@@ -36,13 +36,6 @@ func ResourceIntegrationCloud() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"type": {
-				// This description is used by the documentation generator and the language server.
-				Description: "Type of the Integration. (Supported: aws)",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-			},
 			"name": {
 				// This description is used by the documentation generator and the language server.
 				Description: "Name of the Integration.",
@@ -57,16 +50,27 @@ func ResourceIntegrationCloud() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
-			"aws_template_version": {
-				Description: "The template version of the CloudFormation stack. Use `latest` to stay in sync.",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"aws_s3_bucket_arn": {
-				Description: "The S3 bucket ARN this Cloud Integration is allowed to use for Log Integrations.",
-				Type:        schema.TypeString,
+			"aws": {
+				Description: "Configuration block for AWS integration.",
+				Type:        schema.TypeList,
 				Optional:    true,
-				Default:     "*",
+				MaxItems:    1,
+				ForceNew:    false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"template_version": {
+							Description: "The template version of the CloudFormation stack. Use `latest` to stay in sync.",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"s3_bucket_arn": {
+							Description: "The S3 bucket ARN this Cloud Integration is allowed to use for Log Integrations.",
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "*",
+						},
+					},
+				},
 			},
 			"aws_template_body": {
 				Description: "The template body of the CloudFormation stack.",
@@ -90,8 +94,14 @@ func ResourceIntegrationCloud() *schema.Resource {
 			},
 		},
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
-			if d.HasChange("aws_template_version") {
-				d.SetNewComputed("aws_template_body")
+			if v, ok := d.GetOk("aws"); ok {
+				awsConfigs := v.([]interface{})
+				if len(awsConfigs) > 0 {
+					oldVersion, newVersion := d.GetChange("aws.0.template_version")
+					if oldVersion != newVersion {
+						d.SetNewComputed("aws_template_body")
+					}
+				}
 			}
 			return nil
 		},
@@ -101,18 +111,31 @@ func ResourceIntegrationCloud() *schema.Resource {
 func resourceIntegrationCloudCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*clients.Clients)
 
-	res, err := c.Grpc.Sdk.IntegrationCloudServiceClient.CreateCloudIntegration(ctx, connect.NewRequest(&corev1.CreateCloudIntegrationRequest{
-		Name:               d.Get("name").(string),
-		Type:               d.Get("type").(string),
-		CloudRegion:        d.Get("cloud_region").(string),
-		AwsS3BucketArn:     d.Get("aws_s3_bucket_arn").(string),
-		AwsTemplateVersion: d.Get("aws_template_version").(string),
-	}))
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	d.SetId(res.Msg.Id)
+	name := d.Get("name").(string)
+	cloudRegion := d.Get("cloud_region").(string)
 
+	if v, ok := d.GetOk("aws"); ok {
+		awsConfigs := v.([]interface{})
+		if len(awsConfigs) > 0 {
+			awsConfig := awsConfigs[0].(map[string]interface{})
+
+			res, err := c.Grpc.Sdk.IntegrationCloudServiceClient.CreateCloudIntegration(ctx, connect.NewRequest(&corev1.CreateCloudIntegrationRequest{
+				Name:        name,
+				CloudRegion: cloudRegion,
+
+				Cloud: &corev1.CreateCloudIntegrationRequest_Aws{
+					Aws: &corev1.CreateCloudIntegrationRequest_AWS{
+						S3BucketArn:     awsConfig["s3_bucket_arn"].(string),
+						TemplateVersion: awsConfig["template_version"].(string),
+					},
+				},
+			}))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			d.SetId(res.Msg.Id)
+		}
+	}
 	return resourceIntegrationCloudRead(ctx, d, meta)
 }
 
@@ -139,41 +162,60 @@ func resourceIntegrationCloudRead(ctx context.Context, d *schema.ResourceData, m
 
 	switch data := res.Msg.Cloud.Cloud.(type) {
 	case *corev1.CloudIntegration_Aws:
-		d.Set("type", "aws")
 		d.Set("cloud_region", data.Aws.AwsCloudRegion)
+
+		awsConfig := map[string]interface{}{
+			"template_version": data.Aws.AwsTemplateVersion,
+			"s3_bucket_arn":    data.Aws.AwsS3BucketArn,
+		}
+		if err := d.Set("aws", []interface{}{awsConfig}); err != nil {
+			return diag.FromErr(err)
+		}
+
 		d.Set("aws_template_body", data.Aws.TemplateBody)
 		d.Set("aws_formal_stack_name", data.Aws.AwsFormalStackName)
 		d.Set("aws_formal_iam_role", data.Aws.AwsFormalIamRole)
 		d.Set("aws_formal_pingback_arn", data.Aws.AwsFormalPingbackArn)
-		d.Set("aws_template_version", data.Aws.AwsTemplateVersion)
-		d.Set("aws_s3_bucket_arn", data.Aws.AwsS3BucketArn)
 	}
+
 	return diags
 }
 
 func resourceIntegrationCloudUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*clients.Clients)
-
 	integrationId := d.Id()
 
-	fieldsThatCanChange := []string{"aws_template_version", "aws_s3_bucket_arn"}
+	fieldsThatCanChange := []string{"aws"}
 	if d.HasChangesExcept(fieldsThatCanChange...) {
 		err := fmt.Sprintf("At the moment you can only update the following fields: %s. If you'd like to update other fields, please message the Formal team and we're happy to help.", strings.Join(fieldsThatCanChange, ", "))
 		return diag.Errorf(err)
 	}
 
-	awsTemplateVersion := d.Get("aws_template_version").(string)
-	awsS3BucketArn := d.Get("aws_s3_bucket_arn").(string)
+	var err error
 
-	_, err := c.Grpc.Sdk.IntegrationCloudServiceClient.UpdateCloudIntegration(ctx, connect.NewRequest(&corev1.UpdateCloudIntegrationRequest{
-		Id:                 integrationId,
-		AwsTemplateVersion: &awsTemplateVersion,
-		AwsS3BucketArn:     &awsS3BucketArn,
-	}))
+	if v, ok := d.GetOk("aws"); ok {
+		awsConfigs := v.([]interface{})
+		if len(awsConfigs) > 0 {
+			awsConfig := awsConfigs[0].(map[string]interface{})
+
+			awsTemplateVersion := awsConfig["template_version"].(string)
+			awsS3BucketArn := awsConfig["s3_bucket_arn"].(string)
+
+			_, err = c.Grpc.Sdk.IntegrationCloudServiceClient.UpdateCloudIntegration(ctx, connect.NewRequest(&corev1.UpdateCloudIntegrationRequest{
+				Id: integrationId,
+				Cloud: &corev1.UpdateCloudIntegrationRequest_Aws{
+					Aws: &corev1.UpdateCloudIntegrationRequest_AWS{
+						TemplateVersion: awsTemplateVersion,
+						S3BucketArn:     awsS3BucketArn,
+					},
+				},
+			}))
+		}
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
 	return resourceIntegrationCloudRead(ctx, d, meta)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.1
 
 require (
-	buf.build/gen/go/formal/core/protocolbuffers/go v1.36.5-20250225020200-b6ef428f093a.1
+	buf.build/gen/go/formal/core/protocolbuffers/go v1.36.5-20250226010456-5eee15676522.1
 	connectrpc.com/connect v1.18.1
 	github.com/bufbuild/protovalidate-go v0.9.2
 	github.com/formalco/go-sdk/sdk/v2 v2.8.1
@@ -18,7 +18,7 @@ require (
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.5-20250130201111-63bb56e20495.1 // indirect
-	buf.build/gen/go/formal/core/connectrpc/go v1.18.1-20250225020200-b6ef428f093a.1 // indirect
+	buf.build/gen/go/formal/core/connectrpc/go v1.18.1-20250226010456-5eee15676522.1 // indirect
 	buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.5-20240617172850-a48fcebcf8f1.1 // indirect
 	cel.dev/expr v0.19.1 // indirect
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.5-20250130201111-63bb56e20495.1 h1:cKwn1vgPveeXRDvrt2H+FI5AiBzbG5obrolK8eCAY6U=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.5-20250130201111-63bb56e20495.1/go.mod h1:eOqrCVUfhh7SLo00urDe/XhJHljj0dWMZirS0aX7cmc=
-buf.build/gen/go/formal/core/connectrpc/go v1.18.1-20250225020200-b6ef428f093a.1 h1:VdLWZw1MGr47nRYt9ZY2yMkzEWCAO86DbJ4YfUaVjDc=
-buf.build/gen/go/formal/core/connectrpc/go v1.18.1-20250225020200-b6ef428f093a.1/go.mod h1:mM7xXVdWAw9BUbPNu/dbimaispkx/wgozfx17H4VHeE=
-buf.build/gen/go/formal/core/protocolbuffers/go v1.36.5-20250225020200-b6ef428f093a.1 h1:l7LRTe4kYKDuvO7PrlaxCx7Hujll7hSECJvM1eo492o=
-buf.build/gen/go/formal/core/protocolbuffers/go v1.36.5-20250225020200-b6ef428f093a.1/go.mod h1:ktWxlWHKhhqIUW4LbW41rlyun5U9uSGvWXSFweB6IXA=
+buf.build/gen/go/formal/core/connectrpc/go v1.18.1-20250226010456-5eee15676522.1 h1:+w0qMlMwFHHu+VWYe0iIPsmF7rW7re7EG4j5cib2g2A=
+buf.build/gen/go/formal/core/connectrpc/go v1.18.1-20250226010456-5eee15676522.1/go.mod h1:tNKTxzydxi37DJBK7tjyBadRZWMLy1K2q/NBgdLbiwc=
+buf.build/gen/go/formal/core/protocolbuffers/go v1.36.5-20250226010456-5eee15676522.1 h1:gRVTY7Dzbes5Q3hDBKVV6C0UygmxK86+I2MtRm3H9k8=
+buf.build/gen/go/formal/core/protocolbuffers/go v1.36.5-20250226010456-5eee15676522.1/go.mod h1:ktWxlWHKhhqIUW4LbW41rlyun5U9uSGvWXSFweB6IXA=
 buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.5-20240617172850-a48fcebcf8f1.1 h1:LlB+YL2ftBSwvc61C8R37Tm7sepZOP+ilucoSJe3teA=
 buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.5-20240617172850-a48fcebcf8f1.1/go.mod h1:LAznaLI+eD1SNx+1NfEgrWtuPofvpEP1NTSuCWp3SBw=
 cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=


### PR DESCRIPTION
# Pull Request Description: Cloud Integrations AWS Message

## Provider

### New
- Introduced a new configuration block for AWS integration, allowing users to specify `template_version` and `s3_bucket_arn` under the `aws` key.

### Fixed
- No resolved bugs or issues.

### Changed
- Removed the old `type` field and replaced it with the new `aws` configuration block.
- Updated the resource creation and update logic to use the new AWS configuration structure.
- Adjusted the read logic to properly set the new `aws` configuration from the response.

## Additional Information
This pull request refines the cloud integration process for AWS by consolidating configuration parameters under a single `aws` block, improving organization and clarity. It also ensures that updates can only be made to the `aws` block, preventing unintended changes to other fields. This change enhances the usability and maintainability of the integration configuration.