### PR TITLE
Bring back `type` as a deprecated field

### DIFF
--- a/docs/resources/integration_cloud.md
+++ b/docs/resources/integration_cloud.md
@@ -19,6 +19,7 @@ Registering a Cloud integration.
 
 - `cloud_region` (String) Region of the cloud provider.
 - `name` (String) Name of the Integration.
+- `type` (String, Deprecated) Type of the Integration. (Supported: aws)
 
 ### Optional
 

--- a/formal/resources/resource_integration_cloud.go
+++ b/formal/resources/resource_integration_cloud.go
@@ -36,6 +36,14 @@ func ResourceIntegrationCloud() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"type": {
+				// This description is used by the documentation generator and the language server.
+				Description: "Type of the Integration. (Supported: aws)",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Deprecated:  "This field is deprecated and will be removed in a future version.",
+			},
 			"name": {
 				// This description is used by the documentation generator and the language server.
 				Description: "Name of the Integration.",
@@ -162,6 +170,7 @@ func resourceIntegrationCloudRead(ctx context.Context, d *schema.ResourceData, m
 
 	switch data := res.Msg.Cloud.Cloud.(type) {
 	case *corev1.CloudIntegration_Aws:
+		d.Set("type", "aws")
 		d.Set("cloud_region", data.Aws.AwsCloudRegion)
 
 		awsConfig := map[string]interface{}{


### PR DESCRIPTION
## Provider

### New
- Introduced a deprecated `type` field for the Integration resource.

### Fixed
- No bugs or issues were resolved in this PR.

### Changed
- The `type` field is now included in the integration resource schema as a deprecated field, indicating it will be removed in a future version. The field is marked as required and will always return "aws" for AWS integrations.

## Additional Information
This change is aimed at maintaining backward compatibility while signaling to users that the `type` field is deprecated. Users should transition to using alternative methods for specifying integration types in future versions.