### PR TITLE
Make cloud integrations type optional

### DIFF
--- a/docs/resources/integration_cloud.md
+++ b/docs/resources/integration_cloud.md
@@ -19,12 +19,12 @@ Registering a Cloud integration.
 
 - `cloud_region` (String) Region of the cloud provider.
 - `name` (String) Name of the Integration.
-- `type` (String, Deprecated) Type of the Integration. (Supported: aws)
 
 ### Optional
 
 - `aws` (Block List, Max: 1) Configuration block for AWS integration. (see [below for nested schema](#nestedblock--aws))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `type` (String, Deprecated) Type of the Integration. (Supported: aws)
 
 ### Read-Only
 

--- a/formal/resources/resource_integration_cloud.go
+++ b/formal/resources/resource_integration_cloud.go
@@ -40,8 +40,8 @@ func ResourceIntegrationCloud() *schema.Resource {
 				// This description is used by the documentation generator and the language server.
 				Description: "Type of the Integration. (Supported: aws)",
 				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Optional:    true,
+				Default:     "aws",
 				Deprecated:  "This field is deprecated and will be removed in a future version.",
 			},
 			"name": {


### PR DESCRIPTION
## Provider

### New
- No new features or additions.

### Fixed
- No resolved bugs or issues.

### Changed
- The `type` field for the Integration is now optional instead of required. It has a default value of "aws" and is marked as deprecated, indicating it will be removed in a future version.

## Additional Information
The change to make the `type` field optional allows for greater flexibility in integration configurations while maintaining backward compatibility for existing users. Users should be aware that this field is deprecated and will be removed in future releases. Please update your configurations accordingly.