### PR TITLE
Add support for CF template 1.2.0 feature flags

### DIFF
--- a/docs/resources/integration_cloud.md
+++ b/docs/resources/integration_cloud.md
@@ -28,9 +28,14 @@ Registering a Cloud integration.
 
 ### Read-Only
 
+- `aws_allow_s3_access` (Boolean) Whether AWS S3 access is allowed or not.
+- `aws_enable_eks_autodiscovery` (Boolean) Whether AWS EKS autodiscovery is enabled or not.
+- `aws_enable_rds_autodiscovery` (Boolean) Whether AWS RDS autodiscovery is enabled or not.
+- `aws_enable_redshift_autodiscovery` (Boolean) Whether AWS Redshift autodiscovery is enabled or not.
 - `aws_formal_iam_role` (String) The IAM role ID Formal will use to access your resources.
 - `aws_formal_pingback_arn` (String) The SNS topic ARN CloudFormation can use to send events to Formal.
 - `aws_formal_stack_name` (String) A generated name for your CloudFormation stack.
+- `aws_s3_bucket_arn` (String) The AWS S3 bucket ARN this Cloud Integration is allowed to use for Log Integrations, if it is allowed to access S3.
 - `aws_template_body` (String) The template body of the CloudFormation stack.
 - `id` (String) The ID of the Integration.
 
@@ -43,6 +48,10 @@ Required:
 
 Optional:
 
+- `allow_s3_access` (Boolean) Allows the Cloud Integration to access S3 buckets for Log Integrations.
+- `enable_eks_autodiscovery` (Boolean) Enables resource autodiscovery for EKS clusters.
+- `enable_rds_autodiscovery` (Boolean) Enables resource autodiscovery for RDS instances (PostgreSQL, MySQL, MongoDB).
+- `enable_redshift_autodiscovery` (Boolean) Enables resource autodiscovery for Redshift clusters.
 - `s3_bucket_arn` (String) The S3 bucket ARN this Cloud Integration is allowed to use for Log Integrations.
 
 


### PR DESCRIPTION
## Provider

### New
- Added support for the following feature flags in AWS Cloud Integrations:
  - `allow_s3_access`: Boolean to allow Cloud Integration to access S3 buckets for Log Integrations.
  - `enable_eks_autodiscovery`: Boolean to enable resource autodiscovery for EKS clusters.
  - `enable_rds_autodiscovery`: Boolean to enable resource autodiscovery for RDS instances.
  - `enable_redshift_autodiscovery`: Boolean to enable resource autodiscovery for Redshift clusters.
- Added the following read-only / computed fields to the `formal_integration_cloud` resource, so that it's easier to pass to the CloudFormation stack resource:
  - `aws_allow_s3_access` (Boolean) Whether AWS S3 access is allowed or not.
  - `aws_enable_eks_autodiscovery` (Boolean) Whether AWS EKS autodiscovery is enabled or not.
  - `aws_enable_rds_autodiscovery` (Boolean) Whether AWS RDS autodiscovery is enabled or not.
  - `aws_enable_redshift_autodiscovery` (Boolean) Whether AWS Redshift autodiscovery is enabled or not.

### Fixed
- No fixed issues in this PR.

### Changed
- Updated the CloudFormation integration example to use template version 1.2.0.
- Adjusted resource definitions to include new feature flags and their corresponding descriptions in schema.

## Additional Information
These changes enhance the flexibility and capabilities of our Cloud Integration, allowing users to better manage AWS resources through improved autodiscovery and access controls. Please review the documentation for detailed usage instructions on the new parameters.