### PR TITLE
Do not allow connector listeners to be created on healthcheck port

### DIFF
--- a/formal/resources/resource_connector_listener.go
+++ b/formal/resources/resource_connector_listener.go
@@ -68,9 +68,14 @@ func resourceConnectorListenerCreate(ctx context.Context, d *schema.ResourceData
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 
+	port := d.Get("port").(int)
+	if port == 8080 {
+		return diag.Errorf("connector listener cannot be created on health check port (8080)")
+	}
+
 	req := &corev1.CreateConnectorListenerRequest{
 		Name:                  d.Get("name").(string),
-		Port:                  int32(d.Get("port").(int)),
+		Port:                  int32(port),
 		TerminationProtection: d.Get("termination_protection").(bool),
 	}
 


### PR DESCRIPTION
Throws an error message if you try to create a connector listener on port 8080. 

With the following test resource:
```tf
resource "formal_connector_listener" "example" {
  name = "test"
  port = 8080
}
```

The following error shows up:
![Screenshot 2025-06-17 at 12 22 29 AM](https://github.com/user-attachments/assets/732ffac5-a50c-4367-8a46-35e5dc836418)

Related to TEAMENG-266