### PR TITLE
Fix Formal Integration Mdm Error 

### DIFF
--- a/formal/resources/resource_integration_mdm.go
+++ b/formal/resources/resource_integration_mdm.go
@@ -76,7 +76,7 @@ func resourceIntegrationMDMCreate(ctx context.Context, d *schema.ResourceData, m
 			kandjiConfig := kandjiConfigs[0].(map[string]interface{})
 
 			request := corev1.CreateIntegrationMDMRequest{
-				Name: kandjiConfig["name"].(string),
+				Name: d.Get("name").(string),
 				Integration: &corev1.CreateIntegrationMDMRequest_Kandji_{
 					Kandji: &corev1.CreateIntegrationMDMRequest_Kandji{
 						ApiKey: kandjiConfig["api_key"].(string),


### PR DESCRIPTION
Input Resource:
```
resource "formal_integration_mdm" "dhylan_tf_test_mdm_basic" {
  name = "dhylan-tf-test-mdm-basic"

  kandji {
    api_key = "sdfdsdssd"
    api_url = "https://your-org.api.kandji.io"
  }
}
```
Error:
```
github.com/formalco/terraform-provider-formal/formal/resources.resourceIntegrationMDMCreate({0x10655d148, 0x1400065a5b0}, 0x1400065e360, {0x105f416a0, 0x1400034a038})
        github.com/formalco/terraform-provider-formal/formal/resources/resource_integration_mdm.go:79 +0x42c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x14000021000, {0x10655d0a0, 0x1400064ca80}, 0x1400065e360, {0x105f416a0, 0x1400034a038})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.38.1/helper/schema/resource.go:849 +0xe4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x14000021000, {0x10655d0a0, 0x1400064ca80}, 0x14000676680, 0x1400065e240, {0x105f416a0, 0x1400034a038})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.38.1/helper/schema/resource.go:980 +0x8e8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x140004f5e48, {0x10655d0a0?, 0x1400064c9c0?}, 0x14000654140)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.38.1/helper/schema/grpc_provider.go:1499 +0xd48
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0x1400042a6e0, {0x10655d0a0?, 0x1400064c1b0?}, 0x14000664080)
        github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/tf5server/server.go:944 +0x294
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x106484020, 0x1400042a6e0}, {0x10655d0a0, 0x1400064c1b0}, 0x14000664000, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:789 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x140001aca00, {0x10655d0a0, 0x1400064c120}, 0x14000590120, 0x1400022de90, 0x107865cc8, 0x0)
        google.golang.org/grpc@v1.75.1/server.go:1431 +0xc9c
google.golang.org/grpc.(*Server).handleStream(0x140001aca00, {0x10655d898, 0x140000e6000}, 0x14000590120)
        google.golang.org/grpc@v1.75.1/server.go:1842 +0x900
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.75.1/server.go:1061 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 39
        google.golang.org/grpc@v1.75.1/server.go:1072 +0x138

Error: The terraform-provider-formal_v4.12.5 plugin crashed!
```